### PR TITLE
Fixes a rate rounding problem in grand total

### DIFF
--- a/Kimai2.grandtotalplugin/index.js
+++ b/Kimai2.grandtotalplugin/index.js
@@ -146,8 +146,9 @@ function kimaiGetTimesheets(url, username, token)
     for (var aEntry of aItems)
     {
         var minutes = Math.round(aEntry['duration'] / 60);
-        if (Math.round(aEntry['rate']/minutes*60,2)!=aEntry['rate']/minutes*60) {
-            aEntry['rate'] = minutes / 60 * Math.round(aEntry['rate']/minutes*60,2);
+        var roundedMinutes = aEntry['rate'] / minutes * 60;
+        if (Math.round(roundedMinutes, 2) != roundedMinutes) {
+            aEntry['rate'] = minutes / 60 * Math.round(roundedMinutes, 2);
         }
         var aItemResult = {
             'startDate': aEntry['begin'],

--- a/Kimai2.grandtotalplugin/index.js
+++ b/Kimai2.grandtotalplugin/index.js
@@ -145,11 +145,15 @@ function kimaiGetTimesheets(url, username, token)
 
     for (var aEntry of aItems)
     {
+        var minutes = Math.round(aEntry['duration'] / 60);
+        if (Math.round(aEntry['rate']/minutes*60,2)!=aEntry['rate']/minutes*60) {
+            aEntry['rate'] = minutes / 60 * Math.round(aEntry['rate']/minutes*60,2);
+        }
         var aItemResult = {
             'startDate': aEntry['begin'],
             'client': '',
             'project': '',
-            'minutes': Math.round(aEntry['duration'] / 60),
+            'minutes': minutes,
             'notes': aEntry['description'] !== null ? aEntry['description'] : '',
             'label': aEntry['tags'].join(", "),
             'user': aEntry['user'],


### PR DESCRIPTION
Grandtotal doesn't import the hourly rate - only the cost and the minute. The hourly rate is calculated - this runs in rounding problems for rates not based on 60. This fix produces rates with higher precision if the calculated hourly rate contains more then 2 decimal places.